### PR TITLE
Fail when common ancestor container is root

### DIFF
--- a/FragmentAnchor.js
+++ b/FragmentAnchor.js
@@ -28,6 +28,10 @@ export default class FragmentAnchor {
         throw new Error('no fragment identifier found');
       }
     }
+    
+    if (el === root) {
+      throw new Error('no fragment identifier found');
+    }
 
     return new FragmentAnchor(root, el.id);
   }


### PR DESCRIPTION
Based on the following document:
"If no element can be found in the ancestry of the Range that has a non-empty id attribute and is contained by the root then this function will raise an exception."
The root node should not be considered as a valid common ancestor container. But no error is thrown in this scenario.

fixes #2 